### PR TITLE
Locate binary using github action path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
       shell: bash
       run: |
         set +e
-        bin/ubuntu/mgba-rom-test -S ${{ inputs.swi-call }} -R ${{ inputs.read-register }} ${{ inputs.rom-path }}
+        ${{github.action_path}}/bin/ubuntu/mgba-rom-test -S ${{ inputs.swi-call }} -R ${{ inputs.read-register }} ${{ inputs.rom-path }}
         rom_test_exitcode=$?
         set -e
         echo "::set-output name=exitcode::$rom_test_exitcode"


### PR DESCRIPTION
After reading the [github action docs](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action) a bit, I believe the reason #2 is happening is because the github action's path is not the same as the runner's action path. Therefore, the action looks for the binary within my repository's directory, instead of its own. This isn't a problem when you run tests located within the same repository, but it is when an external repository tries to use the action.

I've put together a quick PR to fix this. It simply locates the binary using the action's path. I've tested this using a fork and [verified it works](https://github.com/Anders429/mgba_tests/actions/runs/8084611900).