### PR TITLE
Stop using deprecated `set-output` command.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,5 +30,5 @@ runs:
         ${{github.action_path}}/bin/ubuntu/mgba-rom-test -S ${{ inputs.swi-call }} -R ${{ inputs.read-register }} ${{ inputs.rom-path }}
         rom_test_exitcode=$?
         set -e
-        echo "::set-output name=exitcode::$rom_test_exitcode"
+        echo "name=exitcode::$rom_test_exitcode" >> $GITHUB_OUTPUT
         if [[ $rom_test_exitcode == ${{ inputs.success-code }} ]]; then exit 0; else exit 1; fi


### PR DESCRIPTION
While using this action, I've noticed a warning:

```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

This PR applies the suggested fix. Prevents the action from being broken whenever they finally decide to fully deprecate `set-output`.

I verified that this change both gets rid of the warning and still allows the action to work correctly by running with the change here: https://github.com/Anders429/mgba_tests/actions/runs/8547610387