### PR TITLE
Update apt index before installing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
         sudo dpkg -i mgba/libmgba.deb
         sudo dpkg -i mgba/mgba-headless.deb
         set -e
-        sudo apt-get install -f
+        sudo apt-get update && sudo apt-get install -f
     - id: mgba-headless
       shell: bash
       run: |


### PR DESCRIPTION
I noticed today that I had some consistent failures with using this action. It was on a private repository, but the relevant part looks like this:

```
 Get:96 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libqt5widgets5t64 amd64 5.15.13+dfsg-1ubuntu1 [2561 kB]
Get:97 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libqt5multimedia5 amd64 5.15.13-1 [310 kB]
Get:98 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libigdgmm12 amd64 22.3.17+ds1-1 [145 kB]
Err:75 https://security.ubuntu.com/ubuntu noble-updates/main amd64 libegl-mesa0 amd64 24.2.8-1ubuntu1~24.04.1
  404  Not Found [IP: 52.252.163.49 80]
Get:99 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 intel-media-va-driver amd64 24.1.0+dfsg1-1 [4022 kB]
Get:100 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libaacs0 amd64 0.11.1-2build1 [62.9 kB]
Get:101 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libbdplus0 amd64 0.2.0-3build1 [52.2 kB]
Get:102 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libdecor-0-plugin-1-gtk amd64 0.2.2-1build2 [22.2 kB]
Get:103 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libqt5qml5 amd64 5.15.13+dfsg-1ubuntu0.1 [1482 kB]
Get:104 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libqt5qmlmodels5 amd64 5.15.13+dfsg-1ubuntu0.1 [203 kB]
Get:105 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libqt5quick5 amd64 5.15.13+dfsg-1ubuntu0.1 [1733 kB]
Get:106 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libqt5svg5 amd64 5.15.13-1 [146 kB]
Get:107 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libqt5waylandclient5 amd64 5.15.13-1 [405 kB]
Get:108 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libqt5waylandcompositor5 amd64 5.15.13-1 [396 kB]
Get:109 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 librsvg2-common amd64 2.58.0+dfsg-1build1 [11.8 kB]
Ign:110 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 mesa-va-drivers amd64 24.2.8-1ubuntu1~24.04.1
Ign:111 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 mesa-vdpau-drivers amd64 24.2.8-1ubuntu1~24.04.1
Get:112 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 qt5-gtk-platformtheme amd64 5.15.13+dfsg-1ubuntu1 [125 kB]
Get:113 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 qttranslations5-l10n all 5.15.13-1 [1964 kB]
Ign:110 https://archive.ubuntu.com/ubuntu noble-updates/universe amd64 mesa-va-drivers amd64 24.2.8-1ubuntu1~24.04.1
Get:114 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 qtwayland5 amd64 5.15.13-1 [223 kB]
Ign:111 https://archive.ubuntu.com/ubuntu noble-updates/main amd64 mesa-vdpau-drivers amd64 24.2.8-1ubuntu1~24.04.1
Err:110 https://security.ubuntu.com/ubuntu noble-updates/universe amd64 mesa-va-drivers amd64 24.2.8-1ubuntu1~24.04.1
  404  Not Found [IP: 52.252.163.49 80]
Get:115 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 i965-va-driver amd64 2.4.1+dfsg1-1build2 [332 kB]
Get:116 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 va-driver-all amd64 2.20.0-2build1 [4844 B]
Err:111 https://security.ubuntu.com/ubuntu noble-updates/main amd64 mesa-vdpau-drivers amd64 24.2.8-1ubuntu1~24.04.1
  404  Not Found [IP: 52.252.163.49 80]
Get:117 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 vdpau-driver-all amd64 1.5-2build1 [4414 B]
Get:118 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 pocketsphinx-en-us all 0.8.0+real5prealpha+1-15ubuntu5 [27.4 MB]
Fetched 108 MB in 6s (17.4 MB/s)
E: Failed to fetch https://security.ubuntu.com/ubuntu/pool/main/m/mesa/libegl-mesa0_24.2.8-1ubuntu1%7e24.04.1_amd64.deb  404  Not Found [IP: 52.252.163.49 80]
E: Failed to fetch https://security.ubuntu.com/ubuntu/pool/universe/m/mesa/mesa-va-drivers_24.2.8-1ubuntu1%7e24.04.1_amd64.deb  404  Not Found [IP: 52.252.163.49 80]
E: Failed to fetch https://security.ubuntu.com/ubuntu/pool/main/m/mesa/mesa-vdpau-drivers_24.2.8-1ubuntu1%7e24.04.1_amd64.deb  404  Not Found [IP: 52.252.163.49 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```

Basically, `sudo apt-get install -f` is failing. From some quick investigation, I came across [this comment](https://github.com/actions/runner-images/issues/6039#issuecomment-1209531257) that indicates we should be running `sudo apt-get update` before installation.

So I've added a call to `sudo apt-get update`. From testing against this change, it seems to have completely resolved the problem I was facing.